### PR TITLE
fix: add scipy to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ moderngl
 moderngl_window
 numpy
 pygments
+scipy
 shapely
 toml
 xxhash


### PR DESCRIPTION
In file `mobjects/mobject.py` imported `scipy` but not written in `requirements.txt`