### PR TITLE
fix: add "svgelements" to "requirements.txt"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ numpy
 pygments
 scipy
 shapely
+svgelements
 toml
 xxhash


### PR DESCRIPTION
Some files import `svgelements` like `mobjects/svg_mobject.py` and `mobjects/path_mobject.py`